### PR TITLE
解决批量发送文本消息报错

### DIFF
--- a/src/Api/Chat.php
+++ b/src/Api/Chat.php
@@ -793,11 +793,11 @@ class Chat extends Base
             'body' => $body,
             'option' => $option,
             'pushcontent' => $pushContent,
-            'payload' => json_encode($payload),
+            //'payload' => json_encode($payload),
             'ext' => $ext,
             'bid' => $bid,
             'useYidun' => $useYidun,
-            'returnMsgid' => $returnMsgid,
+            //'returnMsgid' => $returnMsgid,
         ]);
         return $res;
     }


### PR DESCRIPTION
[ERROR] returnMsgid not boolean[180] in /home/vagrant/code/project/competition/vendor/nizerin/yun-xin-helper/src/Api/Base.php
[ERROR] #0 /home/vagrant/code/project/competition/vendor/nizerin/yun-xin-helper/src/Api/Chat.php(800): YunXinHelper\Api\Base->sendRequest('msg/sendBatchMs...', Array)
#1 /home/vagrant/code/project/competition/vendor/nizerin/yun-xin-helper/src/Api/Chat.php(851): YunXinHelper\Api\Chat->sendBatchMsg('account_2002002...', Array, 0, '{"msg":{"send_t...', '', '', Array, '', '', NULL, true)